### PR TITLE
Switch finetune and smiles app to use entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ After downloading the weights, you can follow `scripts/featurize.py` to load the
 ## Train model from scratch:
 You can use the guacamol dataset (links at the [bottom](#data))
 ```shell script
-python molbert/apps/smiles.py \
+molbert_smiles \
     --train_file data/guacamol_baselines/guacamol_v1_train.smiles \
     --valid_file data/guacamol_baselines/guacamol_v1_valid.smiles \
     --max_seq_length 128 \
@@ -52,7 +52,7 @@ After you have trained a model, and you would like to finetune on a certain trai
 
 For classification you can set can set the mode to `classification` and the `output_size` to 2.
 ```shell script
-python molbert/apps/finetune.py \
+molbert_finetune \
     --train_file path/to/train.csv \
     --valid_file path/to/valid.csv \
     --test_file path/to/test.csv \
@@ -63,7 +63,7 @@ python molbert/apps/finetune.py \
 ```
 For regression set the mode to `regression` and the `output_size` to 1.
 ```shell script
-python molbert/apps/finetune.py \
+molbert_finetune \
     --train_file path/to/train.csv \
     --valid_file path/to/valid.csv \
     --test_file path/to/test.csv \

--- a/molbert/apps/finetune.py
+++ b/molbert/apps/finetune.py
@@ -153,5 +153,9 @@ class FinetuneSmilesMolbertApp(BaseMolbertApp):
         return parsed_args
 
 
+def main():
+    FinetuneSmilesMolbertApp().run()
+
+
 if __name__ == '__main__':
-    trainer = FinetuneSmilesMolbertApp().run()
+    main()

--- a/molbert/apps/smiles.py
+++ b/molbert/apps/smiles.py
@@ -27,5 +27,9 @@ class SmilesMolbertApp(BaseMolbertApp):
         return parser
 
 
-if __name__ == '__main__':
+def main():
     SmilesMolbertApp().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -44,4 +44,10 @@ setup(
         'Programming Language :: Python :: 3',
         'Operating System :: OS Independent',
     ),
+    entry_points={
+        'console_scripts': [
+            'molbert_smiles = molbert.apps.smiles:main',
+            'molbert_finetune = molbert.apps.finetune:main',
+        ],
+    },
 )


### PR DESCRIPTION
This PR does the following:

1. Encompasses the contents of `if __name__ == '__main__': ...` in both `molbert.apps.smiles` and `molbert.apps.finetune` in respective `main()` functions
2. Introduces python entrypoints in the `setup.py` so the `smiles` and `finetune` scripts get vanity commands in the shell upon pip install. Respectively, they are `molbert_smiles` and `molbert_finetune`. This makes it easier to write reproducible scripts that don't rely on the installation to be in a certain place
3. Update the README to reflect the changes in best way to run these apps